### PR TITLE
Refs nf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -21,6 +21,9 @@ include { BAM_TO_FASTQ } from "./modules/local/bam_to_fastq"
 include { SUBSET_ALIGNMENT } from "./modules/local/subset_alignment"
 
 workflow {
+    if (!params.outdir) {
+        exit 1, "Pipeline parameter '--outdir' is mandatory. Please provide a path for the output directory."
+    }
     references_basedir = params.references_basedir
     
     if (params.build_references){

--- a/modules/local/run_hlala/main.nf
+++ b/modules/local/run_hlala/main.nf
@@ -40,9 +40,6 @@ process RUN_HLALA_PLACEHOLDER {
     output:
     tuple val(meta), path("hlala_calls"), emit: hlala_call
 
-    when:
-    meta.single_end
-
     script:
     """
     mkdir -p hlala_calls

--- a/modules/local/run_kourami/kourami_jar/main.nf
+++ b/modules/local/run_kourami/kourami_jar/main.nf
@@ -14,3 +14,20 @@ process RUN_KOURAMI_JAR{
     cp *.result kourami_calls
     """
 }
+
+process RUN_KOURAMI_PLACEHOLDER {
+    tag "$meta.sample"
+    publishDir "${params.outdir}/kourami/${meta.sample}", mode: 'copy'
+
+    input:
+    val meta
+
+    output:
+    tuple val(meta), path("kourami_calls"), emit: kourami_result
+
+    script:
+    """
+    mkdir -p kourami_calls
+    touch kourami_calls/${meta.sample}.result
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,11 +31,22 @@ process {
         memory = { 8.GB.plus(4.GB * task.attempt) }
         cpus = 8
     }
+    /*
     withName: RUN_HLALA {
         container = 'kevinr9525/genome-seek_hla:v1.0.4'
-        cpus = 4
-        memory = { 40.GB + (60.GB * (task.attempt - 1)) }
+        cpus = 12
+        memory = { 212.GB + (60.GB * (task.attempt - 1)) }
+        //memory = { 40.GB + (60.GB * (task.attempt - 1)) }
         maxRetries = 5
+    }
+    */
+    withName: 'RUN_HLALA' {
+        container = 'kevinr9525/genome-seek_hla:v1.0.4'
+        cpus = 12
+        errorStrategy = { task.attempt <= 3 ? 'retry' : 'ignore' }
+        maxRetries = 3
+        // Increase memory with every attempt
+        memory = { 60.GB * task.attempt }
     }
     withLabel: HLALA_CONTAINER {
         container = 'kevinr9525/genome-seek_hla:v1.0.4'
@@ -46,9 +57,13 @@ process {
         container = 'kevinr9525/cancerit-kourami:latest'
     }
     withName: RUN_KOURAMI_JAR {
+        // commenting out to redo voting method
         cpus = 1
         memory = { 18.GB * task.attempt }
+        time = { 2.h * task.attempt }
         container = 'kevinr9525/cancerit-kourami:latest'
+        errorStrategy = { task.attempt <= 3 ? 'retry' : 'ignore' }
+        maxRetries = 3
     }
     withLabel: r_basic_container {
         container = 'kevinr9525/r-basic:dev'
@@ -90,8 +105,9 @@ params {
         voting_method = "majority"
         save_trimmed_fail = false
         save_merged = false
-        tracedir = "${params.outdir}/pipeline_info"
+        tracedir = "${params.outdir}/pipeline_info" 
         trace_report_suffix = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
+        outdir = null
 }
 
 timeline {
@@ -161,9 +177,17 @@ profiles {
         }
     }
     test {
-        samplesheet = "https://raw.githubusercontent.com/kevinpryan/nf-hlamajority/assets/test-dataset/path-to/samplesheet-NA12878-test.csv"
-        outdir = "test-NA12878"
-        aligned = true
-        cram_fasta = "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/GRCh38_full_analysis_set_plus_decoy_hla.fa"
+        params {
+                samplesheet = "https://raw.githubusercontent.com/kevinpryan/nf-hlamajority/refs/heads/main/assets/test-dataset/samplesheet-NA12878-test.csv"
+                aligned = true
+                cram_fasta = "https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/GRCh38_full_analysis_set_plus_decoy_hla.fa"
+        }
+        process {
+                 withName: RUN_HLALA {
+                                      memory = { 35.GB * task.attempt }
+                                      container = 'kevinr9525/genome-seek_hla:v1.0.4'
+                                      cpus = 12
+                 }
+        }
     }
 }

--- a/subworkflows/local/hlala/main.nf
+++ b/subworkflows/local/hlala/main.nf
@@ -1,7 +1,7 @@
 include { RUN_HLALA } from '../../../modules/local/run_hlala'
 include { RUN_HLALA_PLACEHOLDER } from '../../../modules/local/run_hlala'
 
-workflow HLA_LA{
+workflow HLA_LA {
     take: 
     bam
     graphdir
@@ -11,14 +11,42 @@ workflow HLA_LA{
         bam,
         graphdir
     )
-    
+    // need to deal with two scenarios: 1. the user provides a single-end file (skip RUN_HLALA_PLACEHOLDER) 2. RUN_HLALA fails (ignore failure)
+    // Determine who succeeded and who failed/skipped
+    bam
+        // Create a key-only channel [meta] to match against results
+        //.map { meta, bam, bai -> meta }
+        .map { meta, bam, bai -> [ meta ] } // wrap in list to make it a tuple key
+        
+        // Join with results. 'remainder: true' keeps keys even if results are missing.
+        // Result format: [ meta, hlala_output_or_null ]
+        .join(RUN_HLALA.out.hlala_call, remainder: true)
+        
+        // Split into two channels based on whether we got a result
+        .branch { meta, results ->
+            success: results != null
+                return [meta, results]  // Pass the file path
+            failure: results == null
+                return meta    // Pass just the meta for the placeholder
+        }
+        .set { ch_routing }
+
+    // Run placeholder for EVERYONE who didn't get a result
+    // This includes Single-End (skipped) AND Paired-End (failed/ignored)
     RUN_HLALA_PLACEHOLDER(
-        bam.map { meta, aln, bai -> meta }
+        ch_routing.failure
     )
 
+    // Merge results
+    // We reconstruct the [meta, path] tuple for the success channel 
+    // to match the placeholder output structure if needed, 
+    // or just mix if structures align.
+    
+    // Note: ch_routing.success likely looks like [path] or [meta, path] 
+    // depending on exact join behavior. 
+    // join(remainder:true) returns [key, val]. 
+    // So ch_routing.success is [meta, path].
 
     emit:
-    //RUN_HLALA.out.hlala_call
- RUN_HLALA.out.hlala_call
-        .mix(RUN_HLALA_PLACEHOLDER.out.hlala_call)
+    calls = ch_routing.success.mix(RUN_HLALA_PLACEHOLDER.out.hlala_call)
 }

--- a/subworkflows/local/kourami/main.nf
+++ b/subworkflows/local/kourami/main.nf
@@ -4,6 +4,7 @@
 
 include { RUN_KOURAMI_ALIGN_EXTRACT } from '../../../modules/local/run_kourami/align_extract'
 include { RUN_KOURAMI_JAR } from '../../../modules/local/run_kourami/kourami_jar'
+include { RUN_KOURAMI_PLACEHOLDER } from '../../../modules/local/run_kourami/kourami_jar'
 
 workflow KOURAMI {
     
@@ -23,6 +24,29 @@ workflow KOURAMI {
         RUN_KOURAMI_ALIGN_EXTRACT.out.kourami_alignment,
         kourami_panel
     )
+
+    bam
+        // Create a key-only channel from input [meta]
+        //.map { meta, bam, bai -> meta }
+        .map { meta, bam, bai -> [ meta ] } // wrap in list to make it a tuple key
+        // Join with output. If output is missing (timeout), result is null.
+        .join(RUN_KOURAMI_JAR.out.kourami_result, remainder: true)
+        
+        // Split into Success vs Failure
+        .branch { meta, result ->
+            success: result != null
+                return [meta, result] // Return the [meta, path] tuple
+            failure: result == null
+                return meta   // Return just [meta] for the placeholder
+        }
+        .set { ch_kourami_routing }
+
+    // 3. Run Placeholder for Timed Out samples
+    RUN_KOURAMI_PLACEHOLDER(
+        ch_kourami_routing.failure
+    )
+
     emit:
-    RUN_KOURAMI_JAR.out.kourami_result
+    //RUN_KOURAMI_JAR.out.kourami_result
+    calls = ch_kourami_routing.success.mix(RUN_KOURAMI_PLACEHOLDER.out.kourami_result)
 }


### PR DESCRIPTION
This branch is from testing the pipeline on the 1000 genomes data on lugh. It includes commits that allow Kourami and HLA*LA to fail without giving an error - the memory requirements of HLA*LA can become too much to be worth it. Kourami can hang in some cases - it should take minutes rather than hours or days. So if either fails enough times, the placeholder process runs, giving NA. A future update could give some sort of indication as to why the tools gave NA - at the moment it's hard to tell if Kourami gave NA due to taking too long or if it just failed to make a call.

Also, the test profile in nextflow.config here worked on the HLA*LA test data. The user must specify an outdir - attempts to specify a default outdir led to issues in terms of defining the tracedir etc.